### PR TITLE
v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Below is a high level overview of the steps found in the pipeline:
 - Step 9: Export results.
     - The results for this run, along with the code contained within `transform` directory, is written to a zip file with timestamp under the `results` directory. 
 
+## Important Notes
+1. The output dataframe needs to be kept at the same dimension, if you remove rows,  you need to put place holders (like a 0 or empty list).
+
+2. The resulting dataframe's column order matters, as the npy save file does not save column names, so please make sure your decoded dataframe has the same column order.
+
 ## Usage
 To run the encoding and testing pipeline locally, make sure to have [Docker](https://www.docker.com/products/docker-desktop/) and Git installed on your system.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,24 @@
 version: "3.8"
 services:
+  # If cloned with carriage return, remove them (Windows fix)
+  clean-scripts:
+    image: alpine
+    volumes:
+      - ./input:/input
+      - ./output:/output
+      - ./results:/results
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - apk add --no-cache dos2unix &&
+        dos2unix /input/download.sh &&
+        dos2unix /output/search.sh &&
+        dos2unix /results/compute_ratio.sh
+
   # Download test file (if not exists)
   download:
+    depends_on:
+      clean-scripts:
+        condition: service_completed_successfully
     image: alpine/curl
     volumes:
       - ./input:/input


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.yaml` file to address a Windows compatibility issue.

Documentation updates:

Windows compatibility fix:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R3-R21): Added a `clean-scripts` service to remove carriage returns from scripts when cloned on Windows and adjusted the `download` service to depend on the completion of `clean-scripts`.